### PR TITLE
Downpay prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 - Also set PUBLIC_STORE_DOMAIN to your dev store domain
 - `npm i && npm run dev`
 
+# Regenerating GraphQL types
+
+From [the blog post](https://www.shopify.com/ca/partners/blog/introducing-codegen-for-hydrogen)
+
+```
+npm run dev -- --codegen-unstable
+```
+
 # Hydrogen template: Skeleton
 
 Hydrogen is Shopify’s stack for headless commerce. Hydrogen is designed to dovetail with [Remix](https://remix.run/), Shopify’s full stack web framework. This template contains a **minimal setup** of components, queries and tooling to get started with Hydrogen.

--- a/app/components/Cart.tsx
+++ b/app/components/Cart.tsx
@@ -111,6 +111,7 @@ function CartLineItem({
             </li>
           ))}
         </ul>
+        <span><small>{line.sellingPlanAllocation?.sellingPlan.name}</small></span>
         <CartLineQuantity line={line} />
       </div>
     </li>
@@ -146,7 +147,17 @@ export function CartSummary({
     <div aria-labelledby="cart-summary" className={className}>
       <h4>Totals</h4>
       <dl className="cart-subtotal">
-        <dt>Subtotal</dt>
+        <dt>Total Due Today:</dt>
+        <dd>
+          {cost?.checkoutChargeAmount?.amount ? (
+            <Money data={cost?.checkoutChargeAmount} />
+          ) : (
+            '-'
+          )}
+        </dd>
+      </dl>
+      <dl className="cart-subtotal">
+        <dt>Subtotal: </dt>
         <dd>
           {cost?.subtotalAmount?.amount ? (
             <Money data={cost?.subtotalAmount} />

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -13,6 +13,8 @@ import type {
   ProductVariantFragment,
 } from 'storefrontapi.generated';
 
+import { PartialDeep } from 'type-fest';
+
 import {
   Image,
   Money,
@@ -23,6 +25,7 @@ import {
 } from '@shopify/hydrogen';
 import type {
   CartLineInput,
+  ProductVariantConnection,
   SelectedOption,
 } from '@shopify/hydrogen/storefront-api-types';
 import {getVariantUrl} from '~/utils';
@@ -233,7 +236,7 @@ function ProductForm({
       <VariantSelector
         handle={product.handle}
         options={product.options}
-        variants={variants}
+        variants={variants as PartialDeep<ProductVariantConnection>}
       >
         {({option}) => <ProductOptions key={option.name} option={option} />}
       </VariantSelector>
@@ -249,6 +252,7 @@ function ProductForm({
                 {
                   merchandiseId: selectedVariant.id,
                   quantity: 1,
+                  sellingPlanId: selectedVariant.sellingPlanAllocations.edges[0].node.sellingPlan.id,
                 },
               ]
             : []

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -358,6 +358,18 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
       amount
       currencyCode
     }
+    sellingPlanAllocations(first: 1) {
+      edges {
+        cursor
+        node {
+          sellingPlan {
+            id
+            name
+            description
+          }
+        }
+      }
+    }
   }
 ` as const;
 

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -201,7 +201,13 @@ function ProductPrice({
   selectedVariant,
 }: {
   selectedVariant: ProductFragment['selectedVariant'];
-}) {
+  }) {
+  let depositAmount = "";
+  if (selectedVariant?.sellingPlanAllocations.edges[0].node.sellingPlan.checkoutCharge.value.__typename === 'SellingPlanCheckoutChargePercentageValue') {
+    depositAmount = selectedVariant?.sellingPlanAllocations.edges[0].node.sellingPlan.checkoutCharge.value.percentage + '%';
+  } else {
+    depositAmount = selectedVariant?.sellingPlanAllocations.edges[0].node.sellingPlan.checkoutCharge.value.amount || "";
+  }
   return (
     <div className="product-price">
       {selectedVariant?.compareAtPrice ? (
@@ -218,6 +224,9 @@ function ProductPrice({
       ) : (
         selectedVariant?.price && <Money data={selectedVariant?.price} />
       )}
+      <div>
+        Deposit due at checkout: {depositAmount}
+      </div>
     </div>
   );
 }
@@ -370,6 +379,18 @@ const PRODUCT_VARIANT_FRAGMENT = `#graphql
             id
             name
             description
+            checkoutCharge {
+              value {
+                __typename
+                ... on MoneyV2 {
+                  amount
+                  currencyCode
+                }
+                ... on SellingPlanCheckoutChargePercentageValue {
+                  percentage
+                }
+              }
+            }
           }
         }
       }

--- a/server.ts
+++ b/server.ts
@@ -176,6 +176,11 @@ const CART_QUERY_FRAGMENT = `#graphql
         ...Money
       }
     }
+    sellingPlanAllocation {
+      sellingPlan {
+        name
+      }
+    }
     merchandise {
       ... on ProductVariant {
         id
@@ -230,6 +235,10 @@ const CART_QUERY_FRAGMENT = `#graphql
       }
     }
     cost {
+      checkoutChargeAmount {
+        amount
+        currencyCode
+      }
       subtotalAmount {
         ...Money
       }

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -1367,6 +1367,18 @@ export type ProductVariantFragment = Pick<
   unitPrice?: StorefrontAPI.Maybe<
     Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
   >;
+  sellingPlanAllocations: {
+    edges: Array<
+      Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+        node: {
+          sellingPlan: Pick<
+            StorefrontAPI.SellingPlan,
+            'id' | 'name' | 'description'
+          >;
+        };
+      }
+    >;
+  };
 };
 
 export type ProductFragment = Pick<
@@ -1396,6 +1408,18 @@ export type ProductFragment = Pick<
       unitPrice?: StorefrontAPI.Maybe<
         Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
       >;
+      sellingPlanAllocations: {
+        edges: Array<
+          Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+            node: {
+              sellingPlan: Pick<
+                StorefrontAPI.SellingPlan,
+                'id' | 'name' | 'description'
+              >;
+            };
+          }
+        >;
+      };
     }
   >;
   variants: {
@@ -1421,6 +1445,18 @@ export type ProductFragment = Pick<
         unitPrice?: StorefrontAPI.Maybe<
           Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
         >;
+        sellingPlanAllocations: {
+          edges: Array<
+            Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+              node: {
+                sellingPlan: Pick<
+                  StorefrontAPI.SellingPlan,
+                  'id' | 'name' | 'description'
+                >;
+              };
+            }
+          >;
+        };
       }
     >;
   };
@@ -1465,6 +1501,18 @@ export type ProductQuery = {
           unitPrice?: StorefrontAPI.Maybe<
             Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
           >;
+          sellingPlanAllocations: {
+            edges: Array<
+              Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+                node: {
+                  sellingPlan: Pick<
+                    StorefrontAPI.SellingPlan,
+                    'id' | 'name' | 'description'
+                  >;
+                };
+              }
+            >;
+          };
         }
       >;
       variants: {
@@ -1490,6 +1538,18 @@ export type ProductQuery = {
             unitPrice?: StorefrontAPI.Maybe<
               Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
             >;
+            sellingPlanAllocations: {
+              edges: Array<
+                Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+                  node: {
+                    sellingPlan: Pick<
+                      StorefrontAPI.SellingPlan,
+                      'id' | 'name' | 'description'
+                    >;
+                  };
+                }
+              >;
+            };
           }
         >;
       };
@@ -1522,6 +1582,18 @@ export type ProductVariantsFragment = {
         unitPrice?: StorefrontAPI.Maybe<
           Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
         >;
+        sellingPlanAllocations: {
+          edges: Array<
+            Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+              node: {
+                sellingPlan: Pick<
+                  StorefrontAPI.SellingPlan,
+                  'id' | 'name' | 'description'
+                >;
+              };
+            }
+          >;
+        };
       }
     >;
   };
@@ -1558,6 +1630,18 @@ export type ProductVariantsQuery = {
           unitPrice?: StorefrontAPI.Maybe<
             Pick<StorefrontAPI.MoneyV2, 'amount' | 'currencyCode'>
           >;
+          sellingPlanAllocations: {
+            edges: Array<
+              Pick<StorefrontAPI.SellingPlanAllocationEdge, 'cursor'> & {
+                node: {
+                  sellingPlan: Pick<
+                    StorefrontAPI.SellingPlan,
+                    'id' | 'name' | 'description'
+                  >;
+                };
+              }
+            >;
+          };
         }
       >;
     };
@@ -1839,11 +1923,11 @@ interface GeneratedQueryTypes {
     return: PoliciesQuery;
     variables: PoliciesQueryVariables;
   };
-  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    options {\n      name\n      values\n    }\n    selectedVariant: variantBySelectedOptions(selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    variants(first: 1) {\n      nodes {\n        ...ProductVariant \n      }\n    }\n    seo {\n      description\n      title\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n  }\n\n\n': {
+  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    options {\n      name\n      values\n    }\n    selectedVariant: variantBySelectedOptions(selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    variants(first: 1) {\n      nodes {\n        ...ProductVariant \n      }\n    }\n    seo {\n      description\n      title\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n          }\n        }\n      }\n    }\n  }\n\n\n': {
     return: ProductQuery;
     variables: ProductQueryVariables;
   };
-  '#graphql\n  #graphql\n  fragment ProductVariants on Product {\n    variants(first: 250) {\n      nodes {\n        ...ProductVariant\n      }\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n  }\n\n\n  query ProductVariants(\n    $country: CountryCode\n    $language: LanguageCode\n    $handle: String!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...ProductVariants\n    }\n  }\n': {
+  '#graphql\n  fragment ProductVariants on Product {\n    variants(first: 250) {\n      nodes {\n        ...ProductVariant\n      }\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n          }\n        }\n      }\n    }\n  }\n\n  query ProductVariants(\n    $country: CountryCode\n    $language: LanguageCode\n    $handle: String!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...ProductVariants\n    }\n  }\n': {
     return: ProductVariantsQuery;
     variables: ProductVariantsQueryVariables;
   };

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -1374,7 +1374,21 @@ export type ProductVariantFragment = Pick<
           sellingPlan: Pick<
             StorefrontAPI.SellingPlan,
             'id' | 'name' | 'description'
-          >;
+          > & {
+            checkoutCharge: {
+              value:
+                | ({__typename: 'MoneyV2'} & Pick<
+                    StorefrontAPI.MoneyV2,
+                    'amount' | 'currencyCode'
+                  >)
+                | ({
+                    __typename: 'SellingPlanCheckoutChargePercentageValue';
+                  } & Pick<
+                    StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                    'percentage'
+                  >);
+            };
+          };
         };
       }
     >;
@@ -1415,7 +1429,21 @@ export type ProductFragment = Pick<
               sellingPlan: Pick<
                 StorefrontAPI.SellingPlan,
                 'id' | 'name' | 'description'
-              >;
+              > & {
+                checkoutCharge: {
+                  value:
+                    | ({__typename: 'MoneyV2'} & Pick<
+                        StorefrontAPI.MoneyV2,
+                        'amount' | 'currencyCode'
+                      >)
+                    | ({
+                        __typename: 'SellingPlanCheckoutChargePercentageValue';
+                      } & Pick<
+                        StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                        'percentage'
+                      >);
+                };
+              };
             };
           }
         >;
@@ -1452,7 +1480,21 @@ export type ProductFragment = Pick<
                 sellingPlan: Pick<
                   StorefrontAPI.SellingPlan,
                   'id' | 'name' | 'description'
-                >;
+                > & {
+                  checkoutCharge: {
+                    value:
+                      | ({__typename: 'MoneyV2'} & Pick<
+                          StorefrontAPI.MoneyV2,
+                          'amount' | 'currencyCode'
+                        >)
+                      | ({
+                          __typename: 'SellingPlanCheckoutChargePercentageValue';
+                        } & Pick<
+                          StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                          'percentage'
+                        >);
+                  };
+                };
               };
             }
           >;
@@ -1508,7 +1550,21 @@ export type ProductQuery = {
                   sellingPlan: Pick<
                     StorefrontAPI.SellingPlan,
                     'id' | 'name' | 'description'
-                  >;
+                  > & {
+                    checkoutCharge: {
+                      value:
+                        | ({__typename: 'MoneyV2'} & Pick<
+                            StorefrontAPI.MoneyV2,
+                            'amount' | 'currencyCode'
+                          >)
+                        | ({
+                            __typename: 'SellingPlanCheckoutChargePercentageValue';
+                          } & Pick<
+                            StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                            'percentage'
+                          >);
+                    };
+                  };
                 };
               }
             >;
@@ -1545,7 +1601,21 @@ export type ProductQuery = {
                     sellingPlan: Pick<
                       StorefrontAPI.SellingPlan,
                       'id' | 'name' | 'description'
-                    >;
+                    > & {
+                      checkoutCharge: {
+                        value:
+                          | ({__typename: 'MoneyV2'} & Pick<
+                              StorefrontAPI.MoneyV2,
+                              'amount' | 'currencyCode'
+                            >)
+                          | ({
+                              __typename: 'SellingPlanCheckoutChargePercentageValue';
+                            } & Pick<
+                              StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                              'percentage'
+                            >);
+                      };
+                    };
                   };
                 }
               >;
@@ -1589,7 +1659,21 @@ export type ProductVariantsFragment = {
                 sellingPlan: Pick<
                   StorefrontAPI.SellingPlan,
                   'id' | 'name' | 'description'
-                >;
+                > & {
+                  checkoutCharge: {
+                    value:
+                      | ({__typename: 'MoneyV2'} & Pick<
+                          StorefrontAPI.MoneyV2,
+                          'amount' | 'currencyCode'
+                        >)
+                      | ({
+                          __typename: 'SellingPlanCheckoutChargePercentageValue';
+                        } & Pick<
+                          StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                          'percentage'
+                        >);
+                  };
+                };
               };
             }
           >;
@@ -1637,7 +1721,21 @@ export type ProductVariantsQuery = {
                   sellingPlan: Pick<
                     StorefrontAPI.SellingPlan,
                     'id' | 'name' | 'description'
-                  >;
+                  > & {
+                    checkoutCharge: {
+                      value:
+                        | ({__typename: 'MoneyV2'} & Pick<
+                            StorefrontAPI.MoneyV2,
+                            'amount' | 'currencyCode'
+                          >)
+                        | ({
+                            __typename: 'SellingPlanCheckoutChargePercentageValue';
+                          } & Pick<
+                            StorefrontAPI.SellingPlanCheckoutChargePercentageValue,
+                            'percentage'
+                          >);
+                    };
+                  };
                 };
               }
             >;
@@ -1933,11 +2031,11 @@ interface GeneratedQueryTypes {
     return: PoliciesQuery;
     variables: PoliciesQueryVariables;
   };
-  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    options {\n      name\n      values\n    }\n    selectedVariant: variantBySelectedOptions(selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    variants(first: 1) {\n      nodes {\n        ...ProductVariant \n      }\n    }\n    seo {\n      description\n      title\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n          }\n        }\n      }\n    }\n  }\n\n\n': {
+  '#graphql\n  query Product(\n    $country: CountryCode\n    $handle: String!\n    $language: LanguageCode\n    $selectedOptions: [SelectedOptionInput!]!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...Product\n    }\n  }\n  #graphql\n  fragment Product on Product {\n    id\n    title\n    vendor\n    handle\n    descriptionHtml\n    description\n    options {\n      name\n      values\n    }\n    selectedVariant: variantBySelectedOptions(selectedOptions: $selectedOptions) {\n      ...ProductVariant\n    }\n    variants(first: 1) {\n      nodes {\n        ...ProductVariant \n      }\n    }\n    seo {\n      description\n      title\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n            checkoutCharge {\n              value {\n                __typename\n                ... on MoneyV2 {\n                  amount\n                  currencyCode\n                }\n                ... on SellingPlanCheckoutChargePercentageValue {\n                  percentage\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n\n\n': {
     return: ProductQuery;
     variables: ProductQueryVariables;
   };
-  '#graphql\n  fragment ProductVariants on Product {\n    variants(first: 250) {\n      nodes {\n        ...ProductVariant\n      }\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n          }\n        }\n      }\n    }\n  }\n\n  query ProductVariants(\n    $country: CountryCode\n    $language: LanguageCode\n    $handle: String!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...ProductVariants\n    }\n  }\n': {
+  '#graphql\n  fragment ProductVariants on Product {\n    variants(first: 250) {\n      nodes {\n        ...ProductVariant\n      }\n    }\n  }\n  #graphql\n  fragment ProductVariant on ProductVariant {\n    availableForSale\n    compareAtPrice {\n      amount\n      currencyCode\n    }\n    id\n    image {\n      __typename\n      id\n      url\n      altText\n      width\n      height\n    }\n    price {\n      amount\n      currencyCode\n    }\n    product {\n      title\n      handle\n    }\n    selectedOptions {\n      name\n      value\n    }\n    sku\n    title\n    unitPrice {\n      amount\n      currencyCode\n    }\n    sellingPlanAllocations(first: 1) {\n      edges {\n        cursor\n        node {\n          sellingPlan {\n            id\n            name\n            description\n            checkoutCharge {\n              value {\n                __typename\n                ... on MoneyV2 {\n                  amount\n                  currencyCode\n                }\n                ... on SellingPlanCheckoutChargePercentageValue {\n                  percentage\n                }\n              }\n            }\n          }\n        }\n      }\n    }\n  }\n\n  query ProductVariants(\n    $country: CountryCode\n    $language: LanguageCode\n    $handle: String!\n  ) @inContext(country: $country, language: $language) {\n    product(handle: $handle) {\n      ...ProductVariants\n    }\n  }\n': {
     return: ProductVariantsQuery;
     variables: ProductVariantsQueryVariables;
   };

--- a/storefrontapi.generated.d.ts
+++ b/storefrontapi.generated.d.ts
@@ -1765,6 +1765,9 @@ export type CartLineFragment = Pick<
       Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
     >;
   };
+  sellingPlanAllocation?: StorefrontAPI.Maybe<{
+    sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
+  }>;
   merchandise: Pick<
     StorefrontAPI.ProductVariant,
     'id' | 'availableForSale' | 'requiresShipping' | 'title'
@@ -1812,6 +1815,9 @@ export type CartApiQueryFragment = Pick<
             Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>
           >;
         };
+        sellingPlanAllocation?: StorefrontAPI.Maybe<{
+          sellingPlan: Pick<StorefrontAPI.SellingPlan, 'name'>;
+        }>;
         merchandise: Pick<
           StorefrontAPI.ProductVariant,
           'id' | 'availableForSale' | 'requiresShipping' | 'title'
@@ -1835,6 +1841,10 @@ export type CartApiQueryFragment = Pick<
     >;
   };
   cost: {
+    checkoutChargeAmount: Pick<
+      StorefrontAPI.MoneyV2,
+      'amount' | 'currencyCode'
+    >;
     subtotalAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
     totalAmount: Pick<StorefrontAPI.MoneyV2, 'currencyCode' | 'amount'>;
     totalDutyAmount?: StorefrontAPI.Maybe<


### PR DESCRIPTION
Extends the [default hydrogen quickstart](https://shopify.dev/docs/custom-storefronts/hydrogen/getting-started/quickstart) with support for Downpay.

Included:
- Adding the deposit amounts to the product page
- Adding the right parameters to the Add To Cart call so that the purchase option propagates to the cart
- Showing the deposit information in the cart

Here's what that looks like on my dev store. Relevant bits highlighted in green:

Product:
<img width="1421" alt="hydrogen-product" src="https://github.com/HypeHound/hydrogen-demo/assets/209316/48dfc79e-fbec-4d2b-b944-47a6a308505e">
Cart Drawer:
<img width="1718" alt="hydrogen-cart-drawer" src="https://github.com/HypeHound/hydrogen-demo/assets/209316/0909a0e0-df60-4e61-8344-3fa2ee00b000">
Cart:
<img width="1196" alt="hydrogen-cart" src="https://github.com/HypeHound/hydrogen-demo/assets/209316/7bce6545-5d43-40be-838b-70437d776feb">
Checkout:
<img width="1528" alt="hydrogen-checkout" src="https://github.com/HypeHound/hydrogen-demo/assets/209316/c210888f-f959-42ec-bd38-bc50081b9173">

